### PR TITLE
fix type error in eq() call

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ class Experiment:
 
             sort_idxs = sort_idxs.cpu().numpy()
             for j in range(data_batch.shape[0]):
-                rank = np.where(sort_idxs[j]==e2_idx[j])[0][0]
+                rank = np.where(sort_idxs[j]==e2_idx[j].item())[0][0]
                 ranks.append(rank+1)
 
                 for hits_level in range(10):


### PR DESCRIPTION
At least for my setup (torch 1.0.1, numpy 1.15.4) this is needed.